### PR TITLE
fix: modify onEnter event from keydown to keypress

### DIFF
--- a/src/views/GameView.vue
+++ b/src/views/GameView.vue
@@ -16,7 +16,7 @@
             contenteditable="true"
             id="yellow"
             @input="onInput"
-            @keydown.enter.prevent="onEnter"
+            @keypress.enter.prevent="onEnter"
           ></div>
         </span>
       </span>
@@ -141,6 +141,9 @@ export default {
     const onEnter = (event) => {
       if (event.key === "Enter") {
         event.preventDefault();
+        if (!event.target.innerText.trim()) {
+          return;
+        }
         checkAnswer();
         event.target.innerText = "";
         hiddenInput.value.focus();


### PR DESCRIPTION
## AS-IS:
현재 구현 방식: `keydown` 이벤트 사용

## TO-BE:
개선 요청 사항: `keypress` 이벤트로 수정

### Reference
[macOS 한글 입력 문제keydown, keypress](https://velog.io/@hyeon5819/23.6.16-TIL)

Closes #3 